### PR TITLE
Throw error on patch failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,6 +98,7 @@
             "drush/contrib/{$name}": [
                 "type:drupal-drush"
             ]
-        }
+        },
+        "composer-exit-on-patch-failure": true,
     }
 }


### PR DESCRIPTION
Currently composer patches will not halt the build if a patch fails to apply. IMO, this should be the default behavior, but it's not. Fortunately, there's a config to set this :)
